### PR TITLE
Chenge repo of external/cronet to lineageOS from aosp

### DIFF
--- a/snippets/lineage.xml
+++ b/snippets/lineage.xml
@@ -107,6 +107,7 @@
   <project path="external/unrar" name="android_external_unrar" remote="lineage" />
   <project path="external/vim" name="android_external_vim" remote="lineage" />
   <project path="external/json-c" name="android_external_json-c" remote="lineage" />
+  <project path="external/cronet" name="android_external_cronet" remote="lineage" />
 
   <!-- Packages -->
   <project path="packages/apps/Aperture" name="android_packages_apps_Aperture" remote="lineage" />

--- a/snippets/remove.xml
+++ b/snippets/remove.xml
@@ -144,4 +144,5 @@
   <remove-project name="platform/external/libcxx" />
   <remove-project name="platform/external/gptfdisk" />
   <remove-project name="platform/external/dtc" />
+  <remove-project name="platform/external/cronet" />
 </manifest>


### PR DESCRIPTION
To avoid  error of failing command running inside an sbox sandbox, chenge repo of external/cronet to lineageOS from aosp.